### PR TITLE
Select optimization strategy for individual partitions

### DIFF
--- a/core/algorithms/optimization/optimization.hpp
+++ b/core/algorithms/optimization/optimization.hpp
@@ -28,10 +28,10 @@ namespace oracle{
   using part_man_mig_ntk = std::shared_ptr<part_man_mig>;
 
   mig_names optimization(aig_names ntk_aig, part_man_aig partitions_aig, unsigned strategy, unsigned delay_threshold, std::string nn_model,
-			 bool high, bool aig, bool mig, bool combine,
-			 std::set<int32_t> aig_always_partitions, std::set<int32_t> mig_always_partitions,
-			 std::set<int32_t> depth_always_partitions, std::set<int32_t> area_always_partitions,
-			 std::set<int32_t> skip_partitions){
+                         bool high, bool aig, bool mig, bool combine,
+                         std::set<int32_t> aig_always_partitions, std::set<int32_t> mig_always_partitions,
+                         std::set<int32_t> depth_always_partitions, std::set<int32_t> area_always_partitions,
+                         std::set<int32_t> skip_partitions){
 
     mockturtle::direct_resynthesis<mockturtle::mig_network> resyn_mig;
     mockturtle::direct_resynthesis<mockturtle::aig_network> resyn_aig;
@@ -62,9 +62,9 @@ namespace oracle{
           aig_parts.push_back(i);
           continue;
         }
-	if (skip_partitions.find(i) != skip_partitions.end()) {
-	  continue;
-	}
+        if (skip_partitions.find(i) != skip_partitions.end()) {
+          continue;
+        }
 
         oracle::partition_view<aig_names> part_aig = partitions_aig.create_part(ntk_aig, i);
 

--- a/core/algorithms/optimization/optimization.hpp
+++ b/core/algorithms/optimization/optimization.hpp
@@ -26,9 +26,10 @@ namespace oracle{
   using mig_ntk = std::shared_ptr<mig_names>;
   using part_man_mig = oracle::partition_manager<mig_names>;
   using part_man_mig_ntk = std::shared_ptr<part_man_mig>;
-    
-  mig_names optimization(aig_names ntk_aig, part_man_aig partitions_aig, unsigned strategy,std::string nn_model, 
-    bool high, bool aig, bool mig, bool combine){
+
+  mig_names optimization(aig_names ntk_aig, part_man_aig partitions_aig, unsigned strategy,std::string nn_model,
+			 bool high, bool aig, bool mig, bool combine,
+			 std::set<int32_t> aig_always_partitions, std::set<int32_t> mig_always_partitions){
 
     mockturtle::direct_resynthesis<mockturtle::mig_network> resyn_mig;
     mockturtle::direct_resynthesis<mockturtle::aig_network> resyn_aig;
@@ -50,6 +51,14 @@ namespace oracle{
     }
     else if(high){
       for(int i = 0; i < num_parts; i++){
+	if (mig_always_partitions.find(i) != mig_always_partitions.end()) {
+	  mig_parts.push_back(i);
+	  continue;
+	}
+	if (aig_always_partitions.find(i) != aig_always_partitions.end()) {
+	  aig_parts.push_back(i);
+	  continue;
+	}
 
         oracle::partition_view<aig_names> part_aig = partitions_aig.create_part(ntk_aig, i);
 

--- a/core/algorithms/optimization/optimization.hpp
+++ b/core/algorithms/optimization/optimization.hpp
@@ -29,7 +29,8 @@ namespace oracle{
 
   mig_names optimization(aig_names ntk_aig, part_man_aig partitions_aig, unsigned strategy,std::string nn_model,
 			 bool high, bool aig, bool mig, bool combine,
-			 std::set<int32_t> aig_always_partitions, std::set<int32_t> mig_always_partitions){
+			 std::set<int32_t> aig_always_partitions, std::set<int32_t> mig_always_partitions,
+			 std::set<int32_t> depth_always_partitions, std::set<int32_t> area_always_partitions){
 
     mockturtle::direct_resynthesis<mockturtle::mig_network> resyn_mig;
     mockturtle::direct_resynthesis<mockturtle::aig_network> resyn_aig;
@@ -76,6 +77,14 @@ namespace oracle{
         int mig_opt_size = opt_mig.num_gates();
         int mig_opt_depth = part_mig_opt_depth.depth();
 
+	unsigned local_strategy;
+	if (depth_always_partitions.find(i) != depth_always_partitions.end()) {
+	  local_strategy = 2;
+	} else if (area_always_partitions.find(i) != area_always_partitions.end()) {
+	  local_strategy = 1;
+	} else {
+	  local_strategy = strategy;
+	}
         switch(strategy){
           default:
           case 0:

--- a/core/algorithms/optimization/optimization.hpp
+++ b/core/algorithms/optimization/optimization.hpp
@@ -119,18 +119,18 @@ namespace oracle{
           break;
           case 3:
           {
-            if(aig_opt_depth <= delay_threshold && mig_opt_depth > delay_threshold) {
-              aig_parts.push_back(i);
-            } else if (aig_opt_depth > delay_threshold && mig_opt_depth <= delay_threshold) {
-              aig_parts.push_back(i);
-            } else if (aig_opt_depth <= delay_threshold && mig_opt_depth <= delay_threshold) {
+            if (aig_opt_depth <= delay_threshold && mig_opt_depth <= delay_threshold) {
               if (aig_opt_size < mig_opt_size) {
                 aig_parts.push_back(i);
               } else {
                 mig_parts.push_back(i);
               }
+            } else if(aig_opt_depth <= delay_threshold && mig_opt_depth > delay_threshold) {
+              aig_parts.push_back(i);
+            } else if (aig_opt_depth > delay_threshold && mig_opt_depth <= delay_threshold) {
+              mig_parts.push_back(i);
             } else {
-              if((aig_opt_size * aig_opt_depth) <= (mig_opt_size * mig_opt_depth)){
+              if(aig_opt_depth <= mig_opt_depth) {
                 aig_parts.push_back(i);
               } else{
                 mig_parts.push_back(i);

--- a/core/algorithms/optimization/optimization.hpp
+++ b/core/algorithms/optimization/optimization.hpp
@@ -27,7 +27,7 @@ namespace oracle{
   using part_man_mig = oracle::partition_manager<mig_names>;
   using part_man_mig_ntk = std::shared_ptr<part_man_mig>;
 
-  mig_names optimization(aig_names ntk_aig, part_man_aig partitions_aig, unsigned strategy,std::string nn_model,
+  mig_names optimization(aig_names ntk_aig, part_man_aig partitions_aig, unsigned strategy, unsigned delay_threshold, std::string nn_model,
 			 bool high, bool aig, bool mig, bool combine,
 			 std::set<int32_t> aig_always_partitions, std::set<int32_t> mig_always_partitions,
 			 std::set<int32_t> depth_always_partitions, std::set<int32_t> area_always_partitions){
@@ -52,14 +52,14 @@ namespace oracle{
     }
     else if(high){
       for(int i = 0; i < num_parts; i++){
-	if (mig_always_partitions.find(i) != mig_always_partitions.end()) {
-	  mig_parts.push_back(i);
-	  continue;
-	}
-	if (aig_always_partitions.find(i) != aig_always_partitions.end()) {
-	  aig_parts.push_back(i);
-	  continue;
-	}
+        if (mig_always_partitions.find(i) != mig_always_partitions.end()) {
+          mig_parts.push_back(i);
+          continue;
+        }
+        if (aig_always_partitions.find(i) != aig_always_partitions.end()) {
+          aig_parts.push_back(i);
+          continue;
+        }
 
         oracle::partition_view<aig_names> part_aig = partitions_aig.create_part(ntk_aig, i);
 
@@ -77,15 +77,15 @@ namespace oracle{
         int mig_opt_size = opt_mig.num_gates();
         int mig_opt_depth = part_mig_opt_depth.depth();
 
-	unsigned local_strategy;
-	if (depth_always_partitions.find(i) != depth_always_partitions.end()) {
-	  local_strategy = 2;
-	} else if (area_always_partitions.find(i) != area_always_partitions.end()) {
-	  local_strategy = 1;
-	} else {
-	  local_strategy = strategy;
-	}
-        switch(strategy){
+        unsigned local_strategy;
+        if (depth_always_partitions.find(i) != depth_always_partitions.end()) {
+          local_strategy = 2;
+        } else if (area_always_partitions.find(i) != area_always_partitions.end()) {
+          local_strategy = 1;
+        } else {
+          local_strategy = strategy;
+        }
+        switch(local_strategy){
           default:
           case 0:
           {
@@ -117,8 +117,28 @@ namespace oracle{
             }
           }
           break;
+          case 3:
+          {
+            if(aig_opt_depth <= delay_threshold && mig_opt_depth > delay_threshold) {
+              aig_parts.push_back(i);
+            } else if (aig_opt_depth > delay_threshold && mig_opt_depth <= delay_threshold) {
+              aig_parts.push_back(i);
+            } else if (aig_opt_depth <= delay_threshold && mig_opt_depth <= delay_threshold) {
+              if (aig_opt_size < mig_opt_size) {
+                aig_parts.push_back(i);
+              } else {
+                mig_parts.push_back(i);
+              }
+            } else {
+              if((aig_opt_size * aig_opt_depth) <= (mig_opt_size * mig_opt_depth)){
+                aig_parts.push_back(i);
+              } else{
+                mig_parts.push_back(i);
+              }
+            }
+          }
+          break;
         }
-        
       }
     }
     else{

--- a/core/commands/optimization/optimization_command.hpp
+++ b/core/commands/optimization/optimization_command.hpp
@@ -27,12 +27,12 @@ namespace alice
                 opts.add_option( "--nn_model,-n", nn_model, "Trained neural network model for classification" );
                 opts.add_option( "--out,-o", out_file, "Verilog output" );
                 opts.add_option( "--strategy,-s", strategy, "classification strategy [area delay product=0, area=1, delay=2, delay_threshold=3]" );
-		opts.add_option( "--threshold", threshold, "maximum delay threshold for strategy 3" );
-                opts.add_option( "--aig_partitions", aig_parts, "comma separated list of partitions to always be AIG optimized" );
-                opts.add_option( "--mig_partitions", mig_parts, "comma separated list of partitions to always be MIG optimized" );
-                opts.add_option( "--depth_partitions", depth_parts, "comma separated list of partitions to always be depth optimized" );
-                opts.add_option( "--skip_partitions", skip_parts, "comma separated list of partitions that will not be optimized");
-                opts.add_option( "--area_partitions", area_parts, "comma separated list of partitions to always be area optimized" );
+                opts.add_option( "--threshold", threshold, "maximum delay threshold for strategy 3" );
+                opts.add_option( "--aig_partitions", aig_parts, "space separated list of partitions to always be AIG optimized" );
+                opts.add_option( "--mig_partitions", mig_parts, "space separated list of partitions to always be MIG optimized" );
+                opts.add_option( "--depth_partitions", depth_parts, "space separated list of partitions to always be depth optimized" );
+                opts.add_option( "--skip_partitions", skip_parts, "space separated list of partitions that will not be optimized");
+                opts.add_option( "--area_partitions", area_parts, "space separated list of partitions to always be area optimized" );
                 add_flag("--aig,-a", "Perform only AIG optimization on all partitions");
                 add_flag("--mig,-m", "Perform only MIG optimization on all partitions");
                 add_flag("--combine,-c", "Combine adjacent partitions that have been classified for the same optimization");
@@ -58,36 +58,18 @@ namespace alice
             if(is_set("combine"))
               combine = true;
 
-	    {
-	      string tmp;
-	      stringstream as(aig_parts);
-	      while(getline(as, tmp, ',')) {
-		aig_always_partitions.insert(std::stoi(tmp));
-	      }
-	      stringstream ms(mig_parts);
-	      while(getline(ms, tmp, ',')) {
-		mig_always_partitions.insert(std::stoi(tmp));
-	      }
-	      stringstream ds(depth_parts);
-	      while(getline(ds, tmp, ',')) {
-		depth_always_partitions.insert(std::stoi(tmp));
-	      }
-	      stringstream bs(area_parts);
-	      while(getline(bs, tmp, ',')) {
-		area_always_partitions.insert(std::stoi(tmp));
-	      }
-	      stringstream ss(skip_parts);
-	      while(getline(ss, tmp, ',')) {
-		skip_partitions.insert(std::stoi(tmp));
-	      }
-	    }
+            std::copy(aig_parts.begin(), aig_parts.end(), std::inserter(aig_always_partitions, aig_always_partitions.end()));
+            std::copy(mig_parts.begin(), mig_parts.end(), std::inserter(mig_always_partitions, mig_always_partitions.end()));
+            std::copy(area_parts.begin(), area_parts.end(), std::inserter(area_always_partitions, area_always_partitions.end()));
+            std::copy(depth_parts.begin(), depth_parts.end(), std::inserter(depth_always_partitions, depth_always_partitions.end()));
+            std::copy(skip_parts.begin(), skip_parts.end(), std::inserter(skip_partitions, skip_partitions.end()));
 
             auto start = std::chrono::high_resolution_clock::now();
             auto ntk_mig = oracle::optimization(ntk_aig, partitions_aig, strategy, threshold, nn_model,
-						high, aig, mig, combine,
-						aig_always_partitions, mig_always_partitions,
-						depth_always_partitions, area_always_partitions,
-						skip_partitions);
+                                                high, aig, mig, combine,
+                                                aig_always_partitions, mig_always_partitions,
+                                                depth_always_partitions, area_always_partitions,
+                                                skip_partitions);
             auto stop = std::chrono::high_resolution_clock::now();
 
 
@@ -139,11 +121,11 @@ namespace alice
     private:
         std::string nn_model{};
         std::string out_file{};
-        std::string aig_parts{};
-        std::string mig_parts{};
-        std::string area_parts{};
-        std::string depth_parts{};
-        std::string skip_parts{};
+        std::vector<int32_t> aig_parts{};
+        std::vector<int32_t> mig_parts{};
+        std::vector<int32_t> area_parts{};
+        std::vector<int32_t> depth_parts{};
+        std::vector<int32_t> skip_parts{};
         unsigned strategy{0u};
         unsigned threshold{0u};
         bool high = false;

--- a/core/commands/optimization/optimization_command.hpp
+++ b/core/commands/optimization/optimization_command.hpp
@@ -26,7 +26,8 @@ namespace alice
 
                 opts.add_option( "--nn_model,-n", nn_model, "Trained neural network model for classification" );
                 opts.add_option( "--out,-o", out_file, "Verilog output" );
-                opts.add_option( "--strategy,-s", strategy, "classification strategy [area delay product=0, area=1, delay=2]" );
+                opts.add_option( "--strategy,-s", strategy, "classification strategy [area delay product=0, area=1, delay=2, delay_threshold=3]" );
+		opts.add_option( "--threshold", threshold, "maximum delay threshold for strategy 3" );
                 opts.add_option( "--aig_partitions", aig_parts, "comma separated list of partitions to always be AIG optimized" );
                 opts.add_option( "--mig_partitions", mig_parts, "comma separated list of partitions to always be MIG optimized" );
                 opts.add_option( "--depth_partitions", depth_parts, "comma separated list of partitions to always be depth optimized" );
@@ -77,7 +78,7 @@ namespace alice
 	    }
 
             auto start = std::chrono::high_resolution_clock::now();
-            auto ntk_mig = oracle::optimization(ntk_aig, partitions_aig, strategy, nn_model,
+            auto ntk_mig = oracle::optimization(ntk_aig, partitions_aig, strategy, threshold, nn_model,
 						high, aig, mig, combine,
 						aig_always_partitions, mig_always_partitions,
 						depth_always_partitions, area_always_partitions);
@@ -137,6 +138,7 @@ namespace alice
         std::string area_parts{};
         std::string depth_parts{};
         unsigned strategy{0u};
+        unsigned threshold{0u};
         bool high = false;
         bool aig = false;
         bool mig = false;

--- a/core/commands/optimization/optimization_command.hpp
+++ b/core/commands/optimization/optimization_command.hpp
@@ -29,6 +29,8 @@ namespace alice
                 opts.add_option( "--strategy,-s", strategy, "classification strategy [area delay product=0, area=1, delay=2]" );
                 opts.add_option( "--aig_partitions", aig_parts, "comma separated list of partitions to always be AIG optimized" );
                 opts.add_option( "--mig_partitions", mig_parts, "comma separated list of partitions to always be MIG optimized" );
+                opts.add_option( "--depth_partitions", depth_parts, "comma separated list of partitions to always be depth optimized" );
+                opts.add_option( "--area_partitions", area_parts, "comma separated list of partitions to always be area optimized" );
                 add_flag("--aig,-a", "Perform only AIG optimization on all partitions");
                 add_flag("--mig,-m", "Perform only MIG optimization on all partitions");
                 add_flag("--combine,-c", "Combine adjacent partitions that have been classified for the same optimization");
@@ -64,11 +66,21 @@ namespace alice
 	      while(getline(ms, tmp, ',')) {
 		mig_always_partitions.insert(std::stoi(tmp));
 	      }
+	      stringstream ds(depth_parts);
+	      while(getline(ds, tmp, ',')) {
+		depth_always_partitions.insert(std::stoi(tmp));
+	      }
+	      stringstream bs(area_parts);
+	      while(getline(bs, tmp, ',')) {
+		area_always_partitions.insert(std::stoi(tmp));
+	      }
 	    }
 
             auto start = std::chrono::high_resolution_clock::now();
             auto ntk_mig = oracle::optimization(ntk_aig, partitions_aig, strategy, nn_model,
-						high, aig, mig, combine, aig_always_partitions, mig_always_partitions);
+						high, aig, mig, combine,
+						aig_always_partitions, mig_always_partitions,
+						depth_always_partitions, area_always_partitions);
             auto stop = std::chrono::high_resolution_clock::now();
 
 
@@ -122,6 +134,8 @@ namespace alice
         std::string out_file{};
         std::string aig_parts{};
         std::string mig_parts{};
+        std::string area_parts{};
+        std::string depth_parts{};
         unsigned strategy{0u};
         bool high = false;
         bool aig = false;
@@ -129,6 +143,8 @@ namespace alice
         bool combine = false;
         std::set<int32_t> aig_always_partitions = {};
         std::set<int32_t> mig_always_partitions = {};
+        std::set<int32_t> depth_always_partitions = {};
+        std::set<int32_t> area_always_partitions = {};
     };
 
   ALICE_ADD_COMMAND(optimization, "Optimization");

--- a/core/commands/stats/get_cones.hpp
+++ b/core/commands/stats/get_cones.hpp
@@ -30,7 +30,7 @@ namespace alice
     	//number of inputs for each cone
     	std::unordered_map<int, int> po_ins;
     	std::unordered_map<int, int> ri_ins;
-
+	std::cout << "Name Index Nodes Level Inputs\n";
     	//first processing logical cones for POs
     	for(int outIndex=0; outIndex<aig.num_pos()- aig.num_latches(); outIndex++) {
 


### PR DESCRIPTION
Add arguments to the optimization command to specify partitions as always mig, always aig, depth optimized, area optimized, or skipped. Adds a third strategy, to optimize for area unless depth of the partition exceeds a threshold.