### PR TITLE
Link against LibRT on older Linux distros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(Threads REQUIRED)                        # thread library (pthread)
 add_subdirectory(core)
 
+# Link against LibRT on older Linux distros
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+    AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  find_library(LIBRT rt)
+  target_link_libraries(lsoracle ${LIBRT})
+endif()
+
 install(TARGETS lsoracle CONFIGURATIONS RELEASE RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES core/test.ini CONFIGURATIONS RELEASE DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/lsoracle)
 


### PR DESCRIPTION
Fix for The-OpenROAD-Project/OpenROAD-flow-scripts#64

See [here](https://stackoverflow.com/questions/2418157/c-error-undefined-reference-to-clock-gettime-and-clock-settime/32649327#32649327) for explanation